### PR TITLE
Base type is not 'EditorPlugin' error

### DIFF
--- a/addons/zodot/zodot.gd
+++ b/addons/zodot/zodot.gd
@@ -1,4 +1,5 @@
-class_name Zodot
+@tool
+class_name Zodot extends EditorPlugin
 
 var _coerce = false
 var _nullable = false


### PR DESCRIPTION
A small addition to fix "Unable to load addon script from path: 'res://addons/zodot/zodot.gd'. Base type is not 'EditorPlugin'." error.
After extending the plugin from EditorPlugin and adding @tool annotation, plugin now seems to work without a problem.

Using Godot 4.2.1.stable.mono, no other plugin was installed while testing.