### PR TITLE
Added support for non-string field names

### DIFF
--- a/addons/zodot/type_classes/z_aabb.gd
+++ b/addons/zodot/type_classes/z_aabb.gd
@@ -3,7 +3,7 @@ class_name z_aabb extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_AABB
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_array.gd
+++ b/addons/zodot/type_classes/z_array.gd
@@ -13,7 +13,7 @@ func non_empty() -> z_array:
 	_non_empty = true
 	return self
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_basis.gd
+++ b/addons/zodot/type_classes/z_basis.gd
@@ -3,7 +3,7 @@ class_name z_basis extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_BASIS
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_boolean.gd
+++ b/addons/zodot/type_classes/z_boolean.gd
@@ -14,7 +14,7 @@ func _init(kind: Kind) -> void:
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_BOOL
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_callable.gd
+++ b/addons/zodot/type_classes/z_callable.gd
@@ -3,7 +3,7 @@ class_name z_callable extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_CALLABLE
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_color.gd
+++ b/addons/zodot/type_classes/z_color.gd
@@ -3,7 +3,7 @@ class_name z_color extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_COLOR
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_dictionary.gd
+++ b/addons/zodot/type_classes/z_dictionary.gd
@@ -13,7 +13,7 @@ func non_empty() -> z_dictionary:
 	_non_empty = true
 	return self
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_enum.gd
+++ b/addons/zodot/type_classes/z_enum.gd
@@ -18,7 +18,7 @@ var _enum
 func _init(enum_type: Variant):
 	_enum = enum_type
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_float.gd
+++ b/addons/zodot/type_classes/z_float.gd
@@ -14,7 +14,7 @@ func maximum(m: float) -> z_float:
 	_max = m
 	return self
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_integer.gd
+++ b/addons/zodot/type_classes/z_integer.gd
@@ -14,7 +14,7 @@ func maximum(m: int) -> z_integer:
 	_max = m
 	return self
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_literal.gd
+++ b/addons/zodot/type_classes/z_literal.gd
@@ -8,7 +8,7 @@ func _init(value: Variant):
 func _valid_type(value: Variant) -> bool:
 	return true
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 	

--- a/addons/zodot/type_classes/z_max.gd
+++ b/addons/zodot/type_classes/z_max.gd
@@ -3,7 +3,7 @@ class_name z_max extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_MAX
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_nil.gd
+++ b/addons/zodot/type_classes/z_nil.gd
@@ -3,7 +3,7 @@ class_name z_nil extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_NIL
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_node_path.gd
+++ b/addons/zodot/type_classes/z_node_path.gd
@@ -3,7 +3,7 @@ class_name z_node_path extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_NODE_PATH
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_object.gd
+++ b/addons/zodot/type_classes/z_object.gd
@@ -3,7 +3,7 @@ class_name z_object extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_OBJECT
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_packed_byte_array.gd
+++ b/addons/zodot/type_classes/z_packed_byte_array.gd
@@ -3,7 +3,7 @@ class_name z_packed_byte_array extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_PACKED_BYTE_ARRAY
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_packed_color_array.gd
+++ b/addons/zodot/type_classes/z_packed_color_array.gd
@@ -3,7 +3,7 @@ class_name z_packed_color_array extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_PACKED_COLOR_ARRAY
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_packed_float32_array.gd
+++ b/addons/zodot/type_classes/z_packed_float32_array.gd
@@ -3,7 +3,7 @@ class_name z_packed_float32_array extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_PACKED_FLOAT32_ARRAY
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_packed_float64_array.gd
+++ b/addons/zodot/type_classes/z_packed_float64_array.gd
@@ -3,7 +3,7 @@ class_name z_packed_float64_array extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_PACKED_FLOAT64_ARRAY
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_packed_int32_array.gd
+++ b/addons/zodot/type_classes/z_packed_int32_array.gd
@@ -3,7 +3,7 @@ class_name z_packed_int32_array extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_PACKED_INT32_ARRAY
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_packed_int64_array.gd
+++ b/addons/zodot/type_classes/z_packed_int64_array.gd
@@ -3,7 +3,7 @@ class_name z_packed_int64_array extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_PACKED_INT64_ARRAY
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_packed_string_array.gd
+++ b/addons/zodot/type_classes/z_packed_string_array.gd
@@ -3,7 +3,7 @@ class_name z_packed_string_array extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_PACKED_STRING_ARRAY
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_packed_vector2_array.gd
+++ b/addons/zodot/type_classes/z_packed_vector2_array.gd
@@ -3,7 +3,7 @@ class_name z_packed_vector2_array extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_PACKED_VECTOR2_ARRAY
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_packed_vector3_array.gd
+++ b/addons/zodot/type_classes/z_packed_vector3_array.gd
@@ -3,7 +3,7 @@ class_name z_packed_vector3_array extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_PACKED_VECTOR3_ARRAY
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_plane.gd
+++ b/addons/zodot/type_classes/z_plane.gd
@@ -3,7 +3,7 @@ class_name z_plane extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_PLANE
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_projection.gd
+++ b/addons/zodot/type_classes/z_projection.gd
@@ -3,7 +3,7 @@ class_name z_projection extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_PROJECTION
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_quaternion.gd
+++ b/addons/zodot/type_classes/z_quaternion.gd
@@ -3,7 +3,7 @@ class_name z_quaternion extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_QUATERNION
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_rect2.gd
+++ b/addons/zodot/type_classes/z_rect2.gd
@@ -3,7 +3,7 @@ class_name z_rect2 extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_RECT2
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_rect2i.gd
+++ b/addons/zodot/type_classes/z_rect2i.gd
@@ -3,7 +3,7 @@ class_name z_rect2i extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_RECT2I
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_rid.gd
+++ b/addons/zodot/type_classes/z_rid.gd
@@ -3,7 +3,7 @@ class_name z_rid extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_RID
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_schema.gd
+++ b/addons/zodot/type_classes/z_schema.gd
@@ -6,7 +6,7 @@ var _schema: Dictionary
 func _init(schema: Dictionary):
 	_schema = schema
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_signal.gd
+++ b/addons/zodot/type_classes/z_signal.gd
@@ -3,7 +3,7 @@ class_name z_signal extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_SIGNAL
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_string.gd
+++ b/addons/zodot/type_classes/z_string.gd
@@ -19,7 +19,7 @@ func maximum(m: int) -> z_string:
 	_max = m
 	return self
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_string_name.gd
+++ b/addons/zodot/type_classes/z_string_name.gd
@@ -19,7 +19,7 @@ func maximum(m: int) -> z_string_name:
 	_max = m
 	return self
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_transform2d.gd
+++ b/addons/zodot/type_classes/z_transform2d.gd
@@ -3,7 +3,7 @@ class_name z_transform2d extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_TRANSFORM2D
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_transform3d.gd
+++ b/addons/zodot/type_classes/z_transform3d.gd
@@ -3,7 +3,7 @@ class_name z_transform3d extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_TRANSFORM3D
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_union.gd
+++ b/addons/zodot/type_classes/z_union.gd
@@ -5,7 +5,7 @@ var _schemas: Array[Zodot] = []
 func _init(schemas: Array[Zodot]):
 	_schemas = schemas
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _nullable and value == null:
 		return ZodotResult.good(value)
 		

--- a/addons/zodot/type_classes/z_vector2.gd
+++ b/addons/zodot/type_classes/z_vector2.gd
@@ -3,7 +3,7 @@ class_name z_vector2 extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_VECTOR2
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_vector2i.gd
+++ b/addons/zodot/type_classes/z_vector2i.gd
@@ -3,7 +3,7 @@ class_name z_vector2i extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_VECTOR2I
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_vector3.gd
+++ b/addons/zodot/type_classes/z_vector3.gd
@@ -3,7 +3,7 @@ class_name z_vector3 extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_VECTOR3
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_vector3i.gd
+++ b/addons/zodot/type_classes/z_vector3i.gd
@@ -3,7 +3,7 @@ class_name z_vector3i extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_VECTOR3I
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_vector4.gd
+++ b/addons/zodot/type_classes/z_vector4.gd
@@ -3,7 +3,7 @@ class_name z_vector4 extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_VECTOR4
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/type_classes/z_vector4i.gd
+++ b/addons/zodot/type_classes/z_vector4i.gd
@@ -3,7 +3,7 @@ class_name z_vector4i extends Zodot
 func _valid_type(value: Variant) -> bool:
 	return typeof(value) == TYPE_VECTOR4I
 
-func parse(value: Variant, field: String = "") -> ZodotResult:
+func parse(value: Variant, field: Variant = "") -> ZodotResult:
 	if _coerce and typeof(value) == TYPE_STRING:
 		value = str_to_var(value)
 		

--- a/addons/zodot/zodot.gd
+++ b/addons/zodot/zodot.gd
@@ -7,7 +7,7 @@ func _valid_type(_value: Variant) -> bool:
 	# Implemented in subclass
 	return false
 
-func parse(_value: Variant, _field: String = "") -> ZodotResult:
+func parse(_value: Variant, _field: Variant = "") -> ZodotResult:
 	# Implemented in subclass
 	return null
 	


### PR DESCRIPTION
# The Problem I'm Trying to Fix
Godot supports the ability to use integers and Enums (effectiely integers) as keys for dictionaries. From the [docs](https://docs.godotengine.org/en/stable/classes/class_dictionary.html):
<img width="824" alt="Screenshot 2025-01-03 at 2 08 40 am" src="https://github.com/user-attachments/assets/cbdc2962-868d-4a35-b0ac-b5e7557fd76d" />

For example, you can do something like this:
```gdscript
enum FoodTypes { EGGS, BREAD }

var food_amounts = { FoodTypes.EGGS: 3, FoodTypes.BREAD: 10 }
```
However, Zodot would only accept field names as strings. This means we'd have to parse every integer or Enum through `str()`, which is a very cumbersome and inelegant solution. e.g.
```gdscript
var food_amounts = { str(FoodTypes.EGGS): 3, str(FoodTypes.BREAD): 10 }
```

# How Does This PR Fix It?
I've simply loosened up the type safety a little to use `Variant` instead of `String`. Unfortunately there doesn't seem to be any composite types in GDScript.

# Comments
- I have no idea if this is the best solution or approach to this. If there's a reason we'd prefer all fields to be `String`, please let me know!
- Also, great work on the addon!